### PR TITLE
Fix Cartesian conversion

### DIFF
--- a/sknni/__init__.py
+++ b/sknni/__init__.py
@@ -148,9 +148,9 @@ class SkNNI:
         Returns: Cartesian coordinates from the given (lat, lng) coordinates.
         """
 
-        x = r * np.cos(lng) * np.sin(lat)
-        y = r * np.sin(lat) * np.sin(lng)
-        z = r * np.cos(lat)
+        x = r * np.cos(lng) * np.cos(lat)
+        y = r * np.cos(lat) * np.sin(lng)
+        z = r * np.sin(lat)
         return x, y, z
 
     @staticmethod


### PR DESCRIPTION
This PR fixes the Cartesian conversion. The old version assumed the polar angle (latitude) is a measure of inclination (angle from +Z), however the code is setup such that this angle is a measure of elevation (angle from +X). This new version correctly uses the polar angle as a measure of elevation.